### PR TITLE
fix off by one error

### DIFF
--- a/python_scripts/main.py
+++ b/python_scripts/main.py
@@ -29,7 +29,7 @@ scrape_hour = scrape_datetime.hour
 utc_next_execution_date = parse(args.next_execution_date)
 
 # We daily scrape at 3am rather than midnight just to make sure all the data's in the db for the previous day
-scrape_date_yesterday = scrape_date - datetime.timedelta(days=1)
+scrape_date_yesterday = scrape_date # scrape_date is already yesterday
 scrape_date_string_yesterday = scrape_date_yesterday.isoformat()
 
 surveys = get_surveys_from_api()


### PR DESCRIPTION
Airflow executes at the end of the execution period - so for an execution date of 2019-02-13 at 3am, a daily run would execute on 2019-02-14 at 3am. Therefore there's no need to subtract a day from the scrape_date to get yesterday's date, since it already is yesterday.